### PR TITLE
bower@~1.3.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "uglify-js": "~2.3.6",
-    "bower": "~1.0.0",
+    "bower": "~1.3.12",
     "cheerio": "~0.12.1",
     "optimist": "~0.6.0",
     "wrench": "~1.5.1"


### PR DESCRIPTION
This module cannot be installed with `npm@2` because `bower@1.0.3` depends on a range of `bower-config` versions which are prereleases.

Please see https://github.com/npm/npm/issues/6965.

I have no idea if this breaks anything because there are no tests.
